### PR TITLE
Add a tests case to check CI

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -1364,6 +1364,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                 self.check_default_args(item, body_is_trivial)
 
             # Type check body in a new scope.
+            # I am here
             with self.binder.top_frame_context():
                 # Copy some type narrowings from an outer function when it seems safe enough
                 # (i.e. we can't find an assignment that might change the type of the

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -2332,7 +2332,7 @@ def f() -> None:
 o = 1
 [out]
 
-[case testKirillTest]
+[case testReturnDictGetsInferredByFunctionReturnType]
 from typing import Dict
 def f() -> Dict[str, str]: 
     x = {} # E: Need type annotation for "x" (hint: "x: Dict[<type>, <type>] = ...")

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -2332,6 +2332,14 @@ def f() -> None:
 o = 1
 [out]
 
+[case testKirillTest]
+from typing import Dict
+def func() -> Dict[str, str]: 
+    x = {} # E: Need type annotation for "x" (hint: "x: Dict[<type>, <type>] = ...")
+    reveal_type(x) # N: Revealed type is "builtins.dict[builtins.str, builtins.str]"
+    return x
+[out]
+
 [case testMultipassAndClassAttribute]
 class S:
     def foo(self) -> int:
@@ -3913,13 +3921,3 @@ x = "abc"
 for x in list[int]():
     reveal_type(x)  # N: Revealed type is "builtins.int"
 reveal_type(x) # N: Revealed type is "Union[builtins.int, builtins.str]"
-
-[case testInferLocalVariableTypeWithUnderspecifiedGenericTypeKirillTest]
-from typing import TypeVar, Generic
-T = TypeVar('T')
-def g() -> None:
-    x = f() # E: Need type annotation for "test_x"
-
-def f() -> 'A[T]': pass
-class A(Generic[T]): pass
-[out]

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -3913,3 +3913,13 @@ x = "abc"
 for x in list[int]():
     reveal_type(x)  # N: Revealed type is "builtins.int"
 reveal_type(x) # N: Revealed type is "Union[builtins.int, builtins.str]"
+
+[case testInferLocalVariableTypeWithUnderspecifiedGenericTypeKirillTest]
+from typing import TypeVar, Generic
+T = TypeVar('T')
+def g() -> None:
+    x = f() # E: Need type annotation for "test_x"
+
+def f() -> 'A[T]': pass
+class A(Generic[T]): pass
+[out]

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -2334,7 +2334,7 @@ o = 1
 
 [case testKirillTest]
 from typing import Dict
-def func() -> Dict[str, str]: 
+def f() -> Dict[str, str]: 
     x = {} # E: Need type annotation for "x" (hint: "x: Dict[<type>, <type>] = ...")
     reveal_type(x) # N: Revealed type is "builtins.dict[builtins.str, builtins.str]"
     return x


### PR DESCRIPTION
My personal notes, all below might be completely false:

- `check_func_item` seems to be responsible for type inference in a function's arguments and its return type
- `check_func_def` is responsible for type inference in a function's body